### PR TITLE
Vercel hostready

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { signIn } from "next-auth/react"
+import { signIn, signOut } from "next-auth/react"
 import { Palette } from "lucide-react"
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { useToast } from "@/hooks/use-toast"
+import { loginSchema } from "@/lib/auth/validation"
 
 // Define form validation schema using Zod
 const formSchema = z.object({
@@ -46,7 +47,7 @@ function LoginPage() {
 
   // Initialize form with validation schema and default values
   const form = useForm<LoginFormData>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(loginSchema),
     defaultValues: {
       email: "",
       password: "",
@@ -81,7 +82,7 @@ function LoginPage() {
 
       // Add a small delay to ensure session is set
       await new Promise(resolve => setTimeout(resolve, 100))
-      router.push("/dashboard")
+      router.push("/explore")
       router.refresh()
 
     } catch (error) {
@@ -95,6 +96,11 @@ function LoginPage() {
       setIsLoading(false)
     }
   }
+
+  // Logout handler
+  const handleLogout = async () => {
+    await signOut({ callbackUrl: '/' }); // Redirect to home after logout
+  };
 
   return (
     <div className="space-y-6">
@@ -149,6 +155,11 @@ function LoginPage() {
           </Button>
         </form>
       </Form>
+
+      {/* Logout Button */}
+      <Button className="w-full" onClick={handleLogout}>
+        Logout
+      </Button>
 
       {/* Sign up link for new users */}
       <div className="text-center text-sm">

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { hash } from 'bcryptjs';
 import { registerSchema } from '@/lib/auth/validation';
-import clientPromise from '@/lib/db';
+import getMongoClient from '@/lib/db';
 import { sanitizeInput } from '@/lib/utils';
 
 export const dynamic = 'force-dynamic';
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
 
     try {
       // Connect to MongoDB
-      const client = await clientPromise;
+  const client = await getMongoClient();
       const db = client.db('artify');
       const usersCollection = db.collection('users');
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { Palette } from "lucide-react";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export default function DashboardPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  // Redirect to login after mount if unauthenticated
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.replace("/login");
+    }
+  }, [status, router]);
+
+  if (status === "loading") {
+    return null;
+  }
+
+  if (!session) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col items-center space-y-2 text-center">
+        <Link href="/" className="flex items-center space-x-2">
+          <Palette className="h-8 w-8" />
+          <span className="text-2xl font-bold">Artify Dashboard</span>
+        </Link>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Welcome, {session.user.name}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          This is your dashboard.
+        </p>
+      </div>
+      {/* Add more dashboard content here */}
+    </div>
+  );
+} 

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Heart, Share2 } from "lucide-react";
@@ -50,10 +51,13 @@ export default function ExplorePage() {
         {artworks.map((artwork) => (
           <Card key={artwork.id} className="overflow-hidden">
             <div className="aspect-square relative">
-              <img
+              <Image
                 src={artwork.image}
                 alt={artwork.title}
-                className="object-cover w-full h-full hover:scale-105 transition-transform duration-300"
+                fill
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                className="object-cover hover:scale-105 transition-transform duration-300"
+                priority={artwork.id === 1}
               />
             </div>
             <CardContent className="p-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from 'next/font/google';
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 import Navbar from '@/components/navbar';
+import AuthSessionProvider from '@/components/auth-session-provider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -20,18 +21,20 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <Navbar />
-          <main className="min-h-screen bg-background">
-            {children}
-          </main>
-          <Toaster />
-        </ThemeProvider>
+        <AuthSessionProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <Navbar />
+            <main className="min-h-screen bg-background">
+              {children}
+            </main>
+            <Toaster />
+          </ThemeProvider>
+        </AuthSessionProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,13 @@
+"use client"
+
 import { Button } from "@/components/ui/button";
 import { ArrowRight, Palette, Sparkles, Users } from "lucide-react";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 
 export default function Home() {
+  const { data: session } = useSession();
+
   return (
     <div className="flex flex-col items-center">
       {/* Hero Section */}
@@ -18,15 +23,26 @@ export default function Home() {
               </p>
             </div>
             <div className="space-x-4">
-              <Button asChild size="lg">
-                <Link href="/explore">
-                  Explore Artwork
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-              <Button variant="outline" size="lg" asChild>
-                <Link href="/artists">Find Artists</Link>
-              </Button>
+              {session ? (
+                <Button asChild size="lg">
+                  <Link href="/dashboard">
+                    Go to Dashboard
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+              ) : (
+                <>
+                  <Button asChild size="lg">
+                    <Link href="/login">
+                      Login
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                  <Button variant="outline" size="lg" asChild>
+                    <Link href="/signup">Sign Up</Link>
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/components/auth-session-provider.tsx
+++ b/components/auth-session-provider.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import { SessionProvider } from "next-auth/react"
+import type { ReactNode } from "react"
+
+export default function AuthSessionProvider({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,8 +6,12 @@ import Link from "next/link"
 import { Button } from "./ui/button"
 import { ModeToggle } from "./mode-toggle"
 import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet"
+import { useSession } from "next-auth/react"
+import { signOut } from "next-auth/react"
 
 export default function Navbar() {
+  const { data: session } = useSession()
+
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="max-w-7xl mx-auto">
@@ -37,12 +41,20 @@ export default function Navbar() {
             
             {/* Desktop Auth Buttons */}
             <div className="hidden md:flex items-center space-x-4">
-              <Button variant="outline" asChild>
-                <Link href="/login">Login</Link>
-              </Button>
-              <Button asChild>
-                <Link href="/signup">Sign Up</Link>
-              </Button>
+              {session ? (
+                <Button variant="outline" onClick={() => signOut({ callbackUrl: '/' })}>
+                  Logout
+                </Button>
+              ) : (
+                <>
+                  <Button variant="outline" asChild>
+                    <Link href="/login">Login</Link>
+                  </Button>
+                  <Button asChild>
+                    <Link href="/signup">Sign Up</Link>
+                  </Button>
+                </>
+              )}
             </div>
 
             {/* Mobile Menu */}
@@ -64,10 +76,20 @@ export default function Navbar() {
                     Commissions
                   </Link>
                   <Button variant="outline" asChild className="w-full">
-                    <Link href="/login">Login</Link>
+                    {session ? (
+                      <Button variant="outline" onClick={() => signOut({ callbackUrl: '/' })}>
+                        Logout
+                      </Button>
+                    ) : (
+                      <Link href="/login">Login</Link>
+                    )}
                   </Button>
                   <Button asChild className="w-full">
-                    <Link href="/signup">Sign Up</Link>
+                    {session ? (
+                      <Link href="/signup">Sign Up</Link>
+                    ) : (
+                      <Link href="/signup">Sign Up</Link>
+                    )}
                   </Button>
                 </nav>
               </SheetContent>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -75,22 +75,20 @@ export default function Navbar() {
                   <Link href="/commissions" className="text-sm font-medium transition-colors hover:text-primary">
                     Commissions
                   </Link>
-                  <Button variant="outline" asChild className="w-full">
-                    {session ? (
-                      <Button variant="outline" onClick={() => signOut({ callbackUrl: '/' })}>
-                        Logout
+                  {session ? (
+                    <Button variant="outline" className="w-full" onClick={() => signOut({ callbackUrl: '/' })}>
+                      Logout
+                    </Button>
+                  ) : (
+                    <>
+                      <Button variant="outline" asChild className="w-full">
+                        <Link href="/login">Login</Link>
                       </Button>
-                    ) : (
-                      <Link href="/login">Login</Link>
-                    )}
-                  </Button>
-                  <Button asChild className="w-full">
-                    {session ? (
-                      <Link href="/signup">Sign Up</Link>
-                    ) : (
-                      <Link href="/signup">Sign Up</Link>
-                    )}
-                  </Button>
+                      <Button asChild className="w-full">
+                        <Link href="/signup">Sign Up</Link>
+                      </Button>
+                    </>
+                  )}
                 </nav>
               </SheetContent>
             </Sheet>

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -6,7 +6,7 @@ import { Command as CommandPrimitive } from 'cmdk';
 import { Search } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -29,6 +29,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command Palette</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,5 @@
 import { hash, compare } from 'bcryptjs';
-import clientPromise from './db';
+import getMongoClient from './db';
 
 // Function to hash password
 export async function hashPassword(password: string) {
@@ -14,7 +14,7 @@ export async function verifyPassword(password: string, hashedPassword: string) {
 // Function to get user by email
 export async function getUserByEmail(email: string) {
   try {
-    const client = await clientPromise;
+  const client = await getMongoClient();
     const db = client.db();
     return await db.collection('users').findOne({ email });
   } catch (error) {
@@ -27,7 +27,7 @@ export async function getUserByEmail(email: string) {
 export async function createUser(name: string, email: string, password: string, role: 'CUSTOMER' | 'ARTIST') {
   try {
     const hashedPassword = await hashPassword(password);
-    const client = await clientPromise;
+  const client = await getMongoClient();
     const db = client.db();
     
     const result = await db.collection('users').insertOne({

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -1,7 +1,7 @@
 import { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { compare } from 'bcryptjs';
-import clientPromise from './db';
+import getMongoClient from './db';
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -17,7 +17,7 @@ export const authOptions: NextAuthOptions = {
         }
 
         try {
-          const client = await clientPromise;
+          const client = await getMongoClient();
           const db = client.db('artify');
           
           const user = await db.collection('users').findOne({ 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,13 +1,3 @@
-import { PrismaClient } from '@prisma/client';
-
-declare global {
-  var prisma: PrismaClient | undefined;
-}
-
-const prisma = global.prisma || new PrismaClient();
-
-if (process.env.NODE_ENV !== 'production') {
-  global.prisma = prisma;
-}
-
-export default prisma; 
+// Deprecated: Prisma is no longer used in this project.
+// This file is kept as a stub to avoid import errors during cleanup.
+export {};

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,2 @@
-import { createClient } from '@supabase/supabase-js'
-import { Database } from '@/lib/database.types'
-
-// Create a single supabase client for interacting with your database
-export const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+// Deprecated: Supabase is no longer used in this project.
+export {};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
     "@next/swc-wasm-nodejs": "13.5.1",
-    
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
@@ -47,7 +46,10 @@
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "cmdk": "^0.2.0",
+    "date-fns": "^2.30.0",
     "embla-carousel-react": "^8.5.2",
+    "input-otp": "^1.4.2",
     "jose": "^5.2.2",
     "lucide-react": "^0.344.0",
     "mongodb": "^6.3.0",
@@ -59,12 +61,13 @@
     "react-day-picker": "^9.5.1",
     "react-dom": "^18",
     "react-hook-form": "^7.50.1",
+    "react-resizable-panels": "^3.0.5",
     "recharts": "^2.9.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.22.4",
-    "cmdk": "^0.2.0",
-    "date-fns": "^2.30.0"
+    "vaul": "^1.1.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
@@ -76,7 +79,6 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "13.5.1",
     "postcss": "^8.4.35",
-    
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
     "@next/swc-wasm-nodejs": "13.5.1",
-    "@prisma/client": "5.10.2",
+    
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
@@ -76,7 +76,7 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "13.5.1",
     "postcss": "^8.4.35",
-    "prisma": "5.10.2",
+    
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,7 +1,2 @@
-import { PrismaClient } from '@prisma/client';
-
-declare global {
-  var prisma: PrismaClient | undefined;
-}
-
-export {}; 
+// Prisma removed; preserve module shape for TS without adding globals.
+export {};


### PR DESCRIPTION
Implemented lazy MongoDB client with dev caching to avoid build-time connects.
Switched NextAuth to Credentials + JWT and added session provider wrapper.
Updated login to redirect to /explore and improved error toasts.
Signup form now mirrors server Zod rules and shows field-specific errors.
Signup API validates with Zod, sanitizes inputs, hashes passwords, and returns detailed errors.
Added client-only Dashboard page with unauthenticated redirect to /login.
Converted Home to a client component with session-aware CTA buttons.
Added AuthSessionProvider component and integrated it in the root layout.
Revamped Navbar with auth-aware Login/Logout/Signup and responsive mobile menu.
Bumped dependencies (mongodb, next-auth, next) and set Node engine >= 18.17.