### PR TITLE
feat: artwork search/filters + artist availability status

### DIFF
--- a/app/api/artists/route.ts
+++ b/app/api/artists/route.ts
@@ -26,7 +26,12 @@ export async function GET(req: Request) {
       .toArray()
 
     return NextResponse.json({
-      items: items.map((u) => ({ id: String(u._id), name: u.name, avatarUrl: u.avatarUrl || null })),
+      items: items.map((u) => ({
+        id: String(u._id),
+        name: u.name,
+        avatarUrl: u.avatarUrl || null,
+        openToCommissions: (u as any).openToCommissions ?? true,
+      })),
     })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)

--- a/app/api/me/profile/route.ts
+++ b/app/api/me/profile/route.ts
@@ -23,6 +23,7 @@ export async function GET() {
       role: user.role,
       avatarUrl: user.avatarUrl || '',
       bio: user.bio || '',
+      openToCommissions: user.openToCommissions ?? true,
     },
   })
 }
@@ -43,6 +44,7 @@ export async function PATCH(req: Request) {
   if (parsed.data.name !== undefined) patch.name = sanitizeInput(parsed.data.name)
   if (parsed.data.avatarUrl !== undefined) patch.avatarUrl = parsed.data.avatarUrl || null
   if (parsed.data.bio !== undefined) patch.bio = sanitizeInput(parsed.data.bio || '')
+  if (parsed.data.openToCommissions !== undefined) patch.openToCommissions = parsed.data.openToCommissions
   // Role changes are currently disabled; ignore incoming role updates
   patch.updatedAt = new Date()
 

--- a/app/artist/[id]/page.tsx
+++ b/app/artist/[id]/page.tsx
@@ -6,6 +6,7 @@ import { authOptions } from '@/lib/authOptions'
 import { getUserById } from '@/lib/db/users'
 import { listArtworks } from '@/lib/db/artworks'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Share2, SearchX } from 'lucide-react'
@@ -15,6 +16,7 @@ import { FavoriteButton } from '@/components/favorite-button'
 import { getFavoritesCollection } from '@/lib/db/favorites'
 import { ObjectId } from 'mongodb'
 import MyArtworkDelete from '@/components/my-artwork-delete'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 export const dynamic = 'force-dynamic'
 
@@ -47,6 +49,7 @@ export default async function ArtistProfilePage({ params }: PageProps) {
   ])
   if (!artist) return notFound()
   const isSelf = session?.user?.id === id
+  const openToCommissions = (artist as any).openToCommissions ?? true
 
   const { items: artworks, total } = await listArtworks({ artistId: id }, { page: 1, pageSize: 24 })
 
@@ -77,7 +80,12 @@ export default async function ArtistProfilePage({ params }: PageProps) {
           <AvatarFallback>{getInitials(artist.name)}</AvatarFallback>
         </Avatar>
         <div>
-          <h1 className="text-3xl font-bold">{artist.name}</h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-3xl font-bold">{artist.name}</h1>
+            <Badge variant={openToCommissions ? 'default' : 'secondary'}>
+              {openToCommissions ? 'Open to commissions' : 'Not accepting commissions'}
+            </Badge>
+          </div>
           <p className="text-sm text-muted-foreground">{artist.email}</p>
           {artist.bio ? (
             <p className="mt-3 max-w-3xl text-sm leading-relaxed whitespace-pre-line">{artist.bio}</p>
@@ -94,10 +102,23 @@ export default async function ArtistProfilePage({ params }: PageProps) {
                   <Link href="/dashboard/artworks/new">Add artwork</Link>
                 </Button>
               </>
-            ) : (
+            ) : openToCommissions ? (
               <Button asChild>
                 <Link href={`/commissions/new?artistId=${String(artist._id)}`}>Request commission</Link>
               </Button>
+            ) : (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span tabIndex={0}>
+                      <Button disabled>Request commission</Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>This artist is not accepting new commissions right now.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
             <Button asChild variant="outline">
               <Link href="/explore">Browse more artwork</Link>

--- a/app/commissions/new/page.tsx
+++ b/app/commissions/new/page.tsx
@@ -26,7 +26,11 @@ export default async function NewCommissionPage({ searchParams }: PageProps) {
       <p className="text-muted-foreground mb-6">Share your idea and budget. The artist will review and respond.</p>
 
       <CommissionRequestForm
-        presetArtist={artist ? { id: String(artist._id), name: artist.name } : undefined}
+        presetArtist={artist ? {
+          id: String(artist._id),
+          name: artist.name,
+          openToCommissions: (artist as any).openToCommissions ?? true,
+        } : undefined}
         viewerId={session.user.id}
       />
     </div>

--- a/app/commissions/new/request-form.tsx
+++ b/app/commissions/new/request-form.tsx
@@ -11,7 +11,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { toast } from '@/hooks/use-toast'
 import { CommissionCreateSchema } from '@/lib/schemas/commission'
 
-type PresetArtist = { id: string; name: string }
+type PresetArtist = { id: string; name: string; openToCommissions?: boolean }
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
@@ -27,7 +27,7 @@ export function CommissionRequestForm({ presetArtist, viewerId }: { presetArtist
   const [dueDate, setDueDate] = useState('') // yyyy-mm-dd
   const [error, setError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
-  const [suggestions, setSuggestions] = useState<Array<{ id: string; name: string; avatarUrl: string | null }>>([])
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; name: string; avatarUrl: string | null; openToCommissions?: boolean }>>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
 
   const Schema = CommissionCreateSchema
@@ -106,6 +106,14 @@ export function CommissionRequestForm({ presetArtist, viewerId }: { presetArtist
           </AlertDescription>
         </Alert>
       ) : null}
+      {presetArtist && presetArtist.openToCommissions === false ? (
+        <Alert variant="destructive">
+          <AlertTitle>Artist not accepting commissions</AlertTitle>
+          <AlertDescription>
+            This artist is not accepting new commissions right now. You can still submit, but they may decline.
+          </AlertDescription>
+        </Alert>
+      ) : null}
       <div className="space-y-2">
         <label className="text-sm font-medium">Artist</label>
         {presetArtist ? (
@@ -148,6 +156,9 @@ export function CommissionRequestForm({ presetArtist, viewerId }: { presetArtist
                         <AvatarFallback>{(s.name?.[0] || 'A').toUpperCase()}</AvatarFallback>
                       </Avatar>
                       <span className="text-sm">{s.name}</span>
+                      {s.openToCommissions === false && (
+                        <span className="ml-auto text-xs text-muted-foreground">Closed</span>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -28,6 +28,7 @@ export default async function ProfileSettingsPage() {
           avatarUrl: user.avatarUrl || '',
           bio: user.bio || '',
           role: user.role,
+          openToCommissions: (user as any).openToCommissions ?? true,
         }}
       />
     </div>

--- a/app/dashboard/profile/profile-form.tsx
+++ b/app/dashboard/profile/profile-form.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { toast } from '@/hooks/use-toast'
 import { Info } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -15,6 +16,7 @@ type Props = {
     avatarUrl: string
     bio: string
     role: 'CUSTOMER' | 'ARTIST'
+    openToCommissions: boolean
   }
 }
 
@@ -24,17 +26,20 @@ export default function ProfileForm({ initial }: Props) {
   const [avatarUrl, setAvatarUrl] = useState(initial.avatarUrl)
   const [bio, setBio] = useState(initial.bio)
   const [role] = useState<'CUSTOMER' | 'ARTIST'>(initial.role)
+  const [openToCommissions, setOpenToCommissions] = useState(initial.openToCommissions)
   const [error, setError] = useState<string | null>(null)
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError(null)
     try {
+      const body: Record<string, unknown> = { name, avatarUrl, bio }
+      if (role === 'ARTIST') body.openToCommissions = openToCommissions
       const res = await fetch('/api/me/profile', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         // Role changes are restricted for now; omit `role` from the payload
-        body: JSON.stringify({ name, avatarUrl, bio }),
+        body: JSON.stringify(body),
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(data?.error || 'Failed to update profile')
@@ -65,6 +70,22 @@ export default function ProfileForm({ initial }: Props) {
         <label className="text-sm font-medium">Bio</label>
         <Textarea rows={4} value={bio} onChange={(e) => setBio(e.target.value)} />
       </div>
+      {role === 'ARTIST' && (
+        <div className="flex items-center justify-between rounded-lg border p-4">
+          <div className="space-y-0.5">
+            <label className="text-sm font-medium">Open to commissions</label>
+            <p className="text-xs text-muted-foreground">
+              {openToCommissions
+                ? 'Customers can request commissions from you.'
+                : 'Your profile will show you are not accepting new commissions.'}
+            </p>
+          </div>
+          <Switch
+            checked={openToCommissions}
+            onCheckedChange={setOpenToCommissions}
+          />
+        </div>
+      )}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <label className="text-sm font-medium">Role</label>

--- a/app/explore/explore-filters.tsx
+++ b/app/explore/explore-filters.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Search } from 'lucide-react'
+
+interface ExploreFiltersProps {
+  search?: string
+  sort?: string
+  minPrice?: string
+  maxPrice?: string
+  tags?: string
+  my?: string
+}
+
+export function ExploreFilters({
+  search: initSearch = '',
+  sort: initSort = 'new',
+  minPrice: initMin = '',
+  maxPrice: initMax = '',
+  tags,
+  my,
+}: ExploreFiltersProps) {
+  const router = useRouter()
+  const [search, setSearch] = useState(initSearch)
+  const [sort, setSort] = useState(initSort)
+  const [minPrice, setMinPrice] = useState(initMin)
+  const [maxPrice, setMaxPrice] = useState(initMax)
+
+  function buildUrl(overrides: Partial<ExploreFiltersProps> = {}) {
+    const merged = { search, sort, minPrice, maxPrice, tags, my, ...overrides }
+    const sp = new URLSearchParams()
+    if (merged.tags) sp.set('tags', merged.tags)
+    if (merged.my) sp.set('my', merged.my)
+    if (merged.search?.trim()) sp.set('search', merged.search.trim())
+    if (merged.sort && merged.sort !== 'new') sp.set('sort', merged.sort)
+    if (merged.minPrice) sp.set('minPrice', merged.minPrice)
+    if (merged.maxPrice) sp.set('maxPrice', merged.maxPrice)
+    const qs = sp.toString()
+    return qs ? `/explore?${qs}` : '/explore'
+  }
+
+  function applyFilters() {
+    router.push(buildUrl())
+  }
+
+  function clearAll() {
+    setSearch('')
+    setSort('new')
+    setMinPrice('')
+    setMaxPrice('')
+    router.push(buildUrl({ search: '', sort: 'new', minPrice: '', maxPrice: '' }))
+  }
+
+  const hasActiveFilters = !!(search || sort !== 'new' || minPrice || maxPrice)
+
+  return (
+    <div className="flex flex-wrap gap-3 mb-4">
+      <div className="relative flex-1 min-w-[200px] max-w-sm">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          className="pl-9"
+          placeholder="Search artworks..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Input
+          type="number"
+          placeholder="Min $"
+          value={minPrice}
+          onChange={(e) => setMinPrice(e.target.value)}
+          className="w-[90px]"
+          min={0}
+        />
+        <span className="text-muted-foreground text-sm">–</span>
+        <Input
+          type="number"
+          placeholder="Max $"
+          value={maxPrice}
+          onChange={(e) => setMaxPrice(e.target.value)}
+          className="w-[90px]"
+          min={0}
+        />
+      </div>
+
+      <Select value={sort} onValueChange={setSort}>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="new">Newest first</SelectItem>
+          <SelectItem value="priceAsc">Price: Low → High</SelectItem>
+          <SelectItem value="priceDesc">Price: High → Low</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Button onClick={applyFilters}>Apply</Button>
+      {hasActiveFilters && (
+        <Button variant="ghost" onClick={clearAll}>Clear</Button>
+      )}
+    </div>
+  )
+}

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -3,13 +3,14 @@ import Link from 'next/link'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Share2, SearchX } from 'lucide-react'
-import { listArtworks } from '@/lib/db/artworks'
+import { listArtworks, ArtworkSort } from '@/lib/db/artworks'
 import { ArtworkQuickView } from '@/components/artwork-quick-view'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/authOptions'
 import { FavoriteButton } from '@/components/favorite-button'
 import { getFavoritesCollection } from '@/lib/db/favorites'
 import { ObjectId } from 'mongodb'
+import { ExploreFilters } from './explore-filters'
 
 export const dynamic = 'force-dynamic'
 export const metadata = {
@@ -22,6 +23,10 @@ type SearchParams = {
   pageSize?: string
   tags?: string | string[]
   my?: string
+  search?: string
+  sort?: string
+  minPrice?: string
+  maxPrice?: string
 }
 
 function parseIntOr<T extends number>(value: string | undefined, fallback: T, min?: number, max?: number): number {
@@ -44,9 +49,20 @@ export default async function ExplorePage({ searchParams }: { searchParams: Prom
   const activeTag = typeof params.tags === 'string' ? params.tags : undefined
   const myOnly = params.my === '1' && session?.user?.role === 'ARTIST'
 
+  const search = typeof params.search === 'string' ? params.search : undefined
+  const sort = (params.sort as ArtworkSort | undefined) ?? 'new'
+  const minPrice = params.minPrice ? Number(params.minPrice) : undefined
+  const maxPrice = params.maxPrice ? Number(params.maxPrice) : undefined
+
   const { items, total } = await listArtworks(
-    { tags: activeTag ? [activeTag] : undefined, artistId: myOnly ? session!.user.id : undefined },
-    { page, pageSize }
+    {
+      tags: activeTag ? [activeTag] : undefined,
+      artistId: myOnly ? session!.user.id : undefined,
+      search,
+      minPrice: minPrice && !isNaN(minPrice) ? minPrice : undefined,
+      maxPrice: maxPrice && !isNaN(maxPrice) ? maxPrice : undefined,
+    },
+    { page, pageSize, sort }
   )
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
@@ -66,11 +82,25 @@ export default async function ExplorePage({ searchParams }: { searchParams: Prom
 
   const makeHref = (overrides: Partial<SearchParams> = {}) => {
     const sp = new URLSearchParams()
-    const next = { page, pageSize, tags: activeTag, my: myOnly ? '1' : undefined, ...overrides }
+    const next = {
+      page,
+      pageSize,
+      tags: activeTag,
+      my: myOnly ? '1' : undefined,
+      search,
+      sort: sort !== 'new' ? sort : undefined,
+      minPrice: params.minPrice,
+      maxPrice: params.maxPrice,
+      ...overrides,
+    }
     if (next.page && next.page !== 1) sp.set('page', String(next.page))
     if (next.pageSize && next.pageSize !== 12) sp.set('pageSize', String(next.pageSize))
     if (next.tags) sp.set('tags', String(next.tags))
     if (next.my === '1') sp.set('my', '1')
+    if (next.search) sp.set('search', String(next.search))
+    if (next.sort) sp.set('sort', String(next.sort))
+    if (next.minPrice) sp.set('minPrice', String(next.minPrice))
+    if (next.maxPrice) sp.set('maxPrice', String(next.maxPrice))
     const qs = sp.toString()
     return qs ? `/explore?${qs}` : '/explore'
   }
@@ -85,6 +115,16 @@ export default async function ExplorePage({ searchParams }: { searchParams: Prom
           </Button>
         ) : null}
       </div>
+
+      {/* Search, price range, and sort filters */}
+      <ExploreFilters
+        search={search}
+        sort={sort}
+        minPrice={params.minPrice}
+        maxPrice={params.maxPrice}
+        tags={activeTag}
+        my={myOnly ? '1' : undefined}
+      />
 
       {/* Category Chips (single-select) */}
       <div className="mb-6 flex flex-wrap gap-2">
@@ -126,10 +166,12 @@ export default async function ExplorePage({ searchParams }: { searchParams: Prom
           <div>
             <h2 className="text-xl font-semibold">No artworks found</h2>
             <p className="text-sm text-muted-foreground mt-1">
-              {activeTag ? (
-                <>We couldn’t find any items for “{activeTag}”. Try another category or clear the filter.</>
+              {search ? (
+                <>No artworks matched &ldquo;{search}&rdquo;. Try different keywords or clear the search.</>
+              ) : activeTag ? (
+                <>We couldn&apos;t find any items for &ldquo;{activeTag}&rdquo;. Try another category or clear the filter.</>
               ) : (
-                <>There’s nothing to show right now. Try browsing all artwork or check back later.</>
+                <>There&apos;s nothing to show right now. Try browsing all artwork or check back later.</>
               )}
             </p>
           </div>

--- a/lib/db/users.ts
+++ b/lib/db/users.ts
@@ -13,6 +13,7 @@ export interface UserDoc {
   role: 'CUSTOMER' | 'ARTIST'
   avatarUrl?: string
   bio?: string
+  openToCommissions?: boolean
   loginAttempts?: number | null
   lastLoginAttempt?: Date | null
   createdAt: Date
@@ -51,10 +52,10 @@ export async function getUserById(id: string | ObjectId) {
   return col.findOne({ _id }, { projection: { password: 0 } })
 }
 
-/** Update profile fields (name, avatarUrl, bio). */
+/** Update profile fields (name, avatarUrl, bio, openToCommissions). */
 export async function updateUserProfile(
   id: string | ObjectId,
-  patch: Partial<Pick<UserDoc, 'name' | 'avatarUrl' | 'bio'>>
+  patch: Partial<Pick<UserDoc, 'name' | 'avatarUrl' | 'bio' | 'openToCommissions'>>
 ) {
   const col = await getUsersCollection()
   const _id = typeof id === 'string' ? (ObjectId.isValid(id) ? new ObjectId(id) : undefined) : id

--- a/lib/schemas/user.ts
+++ b/lib/schemas/user.ts
@@ -9,6 +9,7 @@ export const UserProfileUpdateSchema = z.object({
     .optional()
     .or(z.literal('')),
   bio: z.string().trim().max(1000, 'Bio must be 1000 characters or fewer').optional().or(z.literal('')),
+  openToCommissions: z.boolean().optional(),
   role: z.enum(['CUSTOMER', 'ARTIST']).optional(),
 })
 


### PR DESCRIPTION
## Summary

- **Explore page search & filters** — wires the existing (but unused) backend search, price range, and sort capabilities to a new `ExploreFilters` client component. No backend changes needed; the DB layer already supported all of this.
- **Artist availability status** — adds an `openToCommissions` boolean to the user model. Artists can toggle it from their profile settings. The public artist profile shows a badge and disables the commission button when closed. The commission request form warns customers when a preset artist is closed and labels closed artists in the search dropdown.

## Changes

### Feature #2 — Search & Filter on Explore Page
- `app/explore/explore-filters.tsx` *(new)* — client component with search input, min/max price fields, and sort dropdown; updates URL params on Apply/Clear
- `app/explore/page.tsx` — reads `search`, `sort`, `minPrice`, `maxPrice` from URL params; passes them to `listArtworks`; renders `ExploreFilters`; `makeHref` preserves all active filters when switching category chips

### Feature #3 — Artist Availability Status
- `lib/db/users.ts` — adds `openToCommissions?: boolean` to `UserDoc`; updates `updateUserProfile` signature
- `lib/schemas/user.ts` — adds `openToCommissions: z.boolean().optional()` to `UserProfileUpdateSchema`
- `app/api/me/profile/route.ts` — GET returns `openToCommissions`; PATCH persists it
- `app/api/artists/route.ts` — search results include `openToCommissions`
- `app/dashboard/profile/profile-form.tsx` — ARTIST role sees a Switch toggle; value is sent in PATCH payload
- `app/dashboard/profile/page.tsx` — passes `openToCommissions` to `ProfileForm`
- `app/artist/[id]/page.tsx` — shows availability Badge next to artist name; commission button is disabled with a Tooltip when artist is closed
- `app/commissions/new/page.tsx` — passes `openToCommissions` through to `CommissionRequestForm`
- `app/commissions/new/request-form.tsx` — shows a destructive Alert when preset artist is closed; artist search dropdown shows "Closed" label for unavailable artists

## Test plan

- [x] Visit `/explore` — confirm search bar, price range inputs, and sort dropdown appear
- [x] Search for a keyword — results filter by title/description; "No artworks found" message mentions the search term
- [x] Set min/max price — results respect the range; Clear button resets all filters
- [x] Change sort to "Price: Low → High" — grid reorders correctly
- [x] Switch category chip while filters are active — chip navigation preserves search/sort/price params
- [x] As an ARTIST, go to `/dashboard/profile` — confirm the "Open to commissions" toggle is visible; toggle off and save
- [x] Visit that artist's public profile `/artist/[id]` — confirm "Not accepting commissions" badge appears and "Request commission" button is disabled with tooltip
- [x] Go to `/commissions/new?artistId=[id]` for a closed artist — confirm the warning Alert renders
- [x] In the commission form artist search, type a name — closed artists show a "Closed" label in the dropdown
- [x] Toggle availability back on — badge updates, button re-enables

https://claude.ai/code/session_01HSAu82rXfxCz8Q1UgRY9f8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSAu82rXfxCz8Q1UgRY9f8)_