### PR TITLE
feat: commission chat — per-request message thread

### DIFF
--- a/app/api/requests/[id]/messages/[msgId]/route.ts
+++ b/app/api/requests/[id]/messages/[msgId]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { ObjectId } from 'mongodb'
+import { authOptions } from '@/lib/auth/authOptions'
+import { requireAuth } from '@/lib/auth/authz'
+import { getRequestById, updateRequestBudget } from '@/lib/db/requests'
+import { getMessageById, updateBidProposalStatus } from '@/lib/db/messages'
+import { BidProposalResponseSchema } from '@/lib/schemas/message'
+
+export const dynamic = 'force-dynamic'
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string; msgId: string }> }) {
+  try {
+    const session = await getServerSession(authOptions)
+    try { requireAuth(session as any) } catch (e) { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+    const { id, msgId } = await params
+    if (!ObjectId.isValid(id) || !ObjectId.isValid(msgId)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 })
+    }
+
+    const request = await getRequestById(id)
+    if (!request) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const uid = (session as any).user.id
+
+    // Only the buyer (customer) can respond to bid proposals
+    if (String(request.customerId) !== uid) {
+      return NextResponse.json({ error: 'Only the buyer can respond to bid proposals' }, { status: 403 })
+    }
+
+    if (request.status === 'DECLINED' || request.status === 'COMPLETED') {
+      return NextResponse.json({ error: 'This request is closed' }, { status: 400 })
+    }
+
+    const message = await getMessageById(msgId)
+    if (!message || String(message.requestId) !== id) {
+      return NextResponse.json({ error: 'Message not found' }, { status: 404 })
+    }
+
+    if (message.type !== 'bid_proposal') {
+      return NextResponse.json({ error: 'This message is not a bid proposal' }, { status: 400 })
+    }
+
+    if (message.bidProposal?.status !== 'pending') {
+      return NextResponse.json({ error: 'This bid proposal is no longer pending' }, { status: 400 })
+    }
+
+    const body = await req.json().catch(() => null)
+    const parsed = BidProposalResponseSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const { action } = parsed.data
+    await updateBidProposalStatus(msgId, action)
+
+    if (action === 'accepted') {
+      await updateRequestBudget(id, message.bidProposal!.amount)
+    }
+
+    return NextResponse.json({ ok: true, action })
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+  }
+}

--- a/app/api/requests/[id]/messages/route.ts
+++ b/app/api/requests/[id]/messages/route.ts
@@ -4,8 +4,8 @@ import { ObjectId } from 'mongodb'
 import { authOptions } from '@/lib/auth/authOptions'
 import { requireAuth } from '@/lib/auth/authz'
 import { getRequestById } from '@/lib/db/requests'
-import { listMessages, createMessage, markMessagesRead } from '@/lib/db/messages'
-import { MessageCreateSchema } from '@/lib/schemas/message'
+import { listMessages, createMessage, markMessagesRead, hasPendingBidProposal } from '@/lib/db/messages'
+import { TextMessageSchema, BidProposalCreateSchema } from '@/lib/schemas/message'
 
 export const dynamic = 'force-dynamic'
 
@@ -32,7 +32,9 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
       messages: raw.map((m) => ({
         id: String(m._id),
         senderId: String(m.senderId),
+        type: m.type,
         body: m.body,
+        bidProposal: m.bidProposal ?? null,
         readAt: m.readAt?.toISOString() ?? null,
         createdAt: m.createdAt.toISOString(),
       })),
@@ -63,7 +65,47 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     }
 
     const body = await req.json().catch(() => null)
-    const parsed = MessageCreateSchema.safeParse(body)
+
+    // Handle bid proposal (artist only)
+    if (body?.type === 'bid_proposal') {
+      if (String(request.artistId) !== uid) {
+        return NextResponse.json({ error: 'Only the artist can propose a new budget' }, { status: 403 })
+      }
+
+      const parsed = BidProposalCreateSchema.safeParse(body)
+      if (!parsed.success) {
+        return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
+      }
+
+      const pending = await hasPendingBidProposal(id)
+      if (pending) {
+        return NextResponse.json({ error: 'There is already a pending bid proposal for this request' }, { status: 409 })
+      }
+
+      const { amount } = parsed.data
+      const message = await createMessage({
+        requestId: request._id!,
+        senderId: new ObjectId(uid),
+        type: 'bid_proposal',
+        body: `Proposed new budget: $${amount.toLocaleString()}`,
+        bidProposal: { amount, status: 'pending' },
+      })
+
+      return NextResponse.json({
+        message: {
+          id: String(message._id),
+          senderId: String(message.senderId),
+          type: message.type,
+          body: message.body,
+          bidProposal: message.bidProposal ?? null,
+          readAt: message.readAt ?? null,
+          createdAt: message.createdAt.toISOString(),
+        },
+      }, { status: 201 })
+    }
+
+    // Handle regular text message
+    const parsed = TextMessageSchema.safeParse(body)
     if (!parsed.success) {
       return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
     }
@@ -71,6 +113,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     const message = await createMessage({
       requestId: request._id!,
       senderId: new ObjectId(uid),
+      type: 'text',
       body: parsed.data.body,
     })
 
@@ -78,7 +121,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       message: {
         id: String(message._id),
         senderId: String(message.senderId),
+        type: message.type,
         body: message.body,
+        bidProposal: null,
         readAt: message.readAt ?? null,
         createdAt: message.createdAt.toISOString(),
       },

--- a/app/api/requests/[id]/messages/route.ts
+++ b/app/api/requests/[id]/messages/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { ObjectId } from 'mongodb'
+import { authOptions } from '@/lib/auth/authOptions'
+import { requireAuth } from '@/lib/auth/authz'
+import { getRequestById } from '@/lib/db/requests'
+import { listMessages, createMessage, markMessagesRead } from '@/lib/db/messages'
+import { MessageCreateSchema } from '@/lib/schemas/message'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await getServerSession(authOptions)
+    try { requireAuth(session as any) } catch (e) { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+    const { id } = await params
+    if (!ObjectId.isValid(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 })
+
+    const request = await getRequestById(id)
+    if (!request) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const uid = (session as any).user.id
+    if (String(request.artistId) !== uid && String(request.customerId) !== uid) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const raw = await listMessages(id)
+    await markMessagesRead(id, uid)
+
+    return NextResponse.json({
+      messages: raw.map((m) => ({
+        id: String(m._id),
+        senderId: String(m.senderId),
+        body: m.body,
+        readAt: m.readAt?.toISOString() ?? null,
+        createdAt: m.createdAt.toISOString(),
+      })),
+    })
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await getServerSession(authOptions)
+    try { requireAuth(session as any) } catch (e) { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+    const { id } = await params
+    if (!ObjectId.isValid(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 })
+
+    const request = await getRequestById(id)
+    if (!request) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    if (request.status === 'DECLINED' || request.status === 'COMPLETED') {
+      return NextResponse.json({ error: 'This request is closed for new messages' }, { status: 400 })
+    }
+
+    const uid = (session as any).user.id
+    if (String(request.artistId) !== uid && String(request.customerId) !== uid) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = await req.json().catch(() => null)
+    const parsed = MessageCreateSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const message = await createMessage({
+      requestId: request._id!,
+      senderId: new ObjectId(uid),
+      body: parsed.data.body,
+    })
+
+    return NextResponse.json({
+      message: {
+        id: String(message._id),
+        senderId: String(message.senderId),
+        body: message.body,
+        readAt: message.readAt ?? null,
+        createdAt: message.createdAt.toISOString(),
+      },
+    }, { status: 201 })
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+  }
+}

--- a/app/requests/[id]/bid-proposal-button.tsx
+++ b/app/requests/[id]/bid-proposal-button.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { DollarSign } from 'lucide-react'
+
+interface Props {
+  requestId: string
+  hasPendingBid: boolean
+}
+
+export function BidProposalButton({ requestId, hasPendingBid }: Props) {
+  const router = useRouter()
+  const [showForm, setShowForm] = useState(false)
+  const [amount, setAmount] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [, startTransition] = useTransition()
+
+  async function submit() {
+    const num = parseFloat(amount)
+    if (!Number.isFinite(num) || num <= 0) {
+      setError('Please enter a valid positive amount')
+      return
+    }
+    setError(null)
+    setPending(true)
+    try {
+      const res = await fetch(`/api/requests/${requestId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'bid_proposal', amount: num }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error || 'Failed to submit proposal')
+      setShowForm(false)
+      setAmount('')
+      startTransition(() => router.refresh())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to submit proposal')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  if (hasPendingBid) {
+    return (
+      <span className="text-xs text-muted-foreground italic">
+        Awaiting buyer response on budget proposal
+      </span>
+    )
+  }
+
+  if (showForm) {
+    return (
+      <div className="rounded-lg border bg-background p-3 space-y-2 w-full">
+        <p className="text-xs font-medium">Propose a new budget</p>
+        {error && <p className="text-xs text-red-600">{error}</p>}
+        <div className="flex gap-2 items-center">
+          <span className="text-sm text-muted-foreground">$</span>
+          <Input
+            type="number"
+            inputMode="decimal"
+            placeholder="Enter amount"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            min={0}
+            className="h-8 text-sm"
+            disabled={pending}
+          />
+        </div>
+        <div className="flex gap-2 justify-end">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => { setShowForm(false); setAmount(''); setError(null) }}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={submit} disabled={pending}>
+            {pending ? 'Sending…' : 'Send proposal'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => setShowForm(true)}
+      className="gap-1.5"
+    >
+      <DollarSign className="h-4 w-4" />
+      Propose budget
+    </Button>
+  )
+}

--- a/app/requests/[id]/bid-proposal-button.tsx
+++ b/app/requests/[id]/bid-proposal-button.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { DollarSign } from 'lucide-react'
+import { DollarSign, Clock } from 'lucide-react'
 
 interface Props {
   requestId: string
@@ -15,9 +15,15 @@ export function BidProposalButton({ requestId, hasPendingBid }: Props) {
   const router = useRouter()
   const [showForm, setShowForm] = useState(false)
   const [amount, setAmount] = useState('')
-  const [pending, setPending] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [, startTransition] = useTransition()
+
+  function cancel() {
+    setShowForm(false)
+    setAmount('')
+    setError(null)
+  }
 
   async function submit() {
     const num = parseFloat(amount)
@@ -26,7 +32,7 @@ export function BidProposalButton({ requestId, hasPendingBid }: Props) {
       return
     }
     setError(null)
-    setPending(true)
+    setSubmitting(true)
     try {
       const res = await fetch(`/api/requests/${requestId}/messages`, {
         method: 'POST',
@@ -35,53 +41,63 @@ export function BidProposalButton({ requestId, hasPendingBid }: Props) {
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(data?.error || 'Failed to submit proposal')
-      setShowForm(false)
-      setAmount('')
+      cancel()
       startTransition(() => router.refresh())
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to submit proposal')
     } finally {
-      setPending(false)
+      setSubmitting(false)
     }
   }
 
   if (hasPendingBid) {
     return (
-      <span className="text-xs text-muted-foreground italic">
-        Awaiting buyer response on budget proposal
-      </span>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium">Budget proposal sent</p>
+          <p className="text-xs text-muted-foreground mt-0.5">Waiting for the buyer to respond.</p>
+        </div>
+        <div className="flex items-center gap-1.5 rounded-full bg-amber-100 dark:bg-amber-900/30 px-3 py-1 text-amber-700 dark:text-amber-400">
+          <Clock className="h-3 w-3 shrink-0" />
+          <span className="text-xs font-medium whitespace-nowrap">Pending</span>
+        </div>
+      </div>
     )
   }
 
   if (showForm) {
     return (
-      <div className="rounded-lg border bg-background p-3 space-y-2 w-full">
-        <p className="text-xs font-medium">Propose a new budget</p>
-        {error && <p className="text-xs text-red-600">{error}</p>}
-        <div className="flex gap-2 items-center">
-          <span className="text-sm text-muted-foreground">$</span>
+      <div className="space-y-3">
+        <div>
+          <p className="text-sm font-medium">Suggest a budget adjustment</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            The buyer will see this in the chat and can accept or decline.
+          </p>
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <div className="relative">
+          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm text-muted-foreground select-none">
+            $
+          </span>
           <Input
             type="number"
             inputMode="decimal"
-            placeholder="Enter amount"
+            placeholder="0"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             min={0}
-            className="h-8 text-sm"
-            disabled={pending}
+            className="pl-7"
+            disabled={submitting}
+            autoFocus
+            onKeyDown={(e) => { if (e.key === 'Enter') submit() }}
           />
         </div>
-        <div className="flex gap-2 justify-end">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => { setShowForm(false); setAmount(''); setError(null) }}
-            disabled={pending}
-          >
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" className="flex-1" onClick={cancel} disabled={submitting}>
             Cancel
           </Button>
-          <Button size="sm" onClick={submit} disabled={pending}>
-            {pending ? 'Sending…' : 'Send proposal'}
+          <Button size="sm" className="flex-1" onClick={submit} disabled={submitting}>
+            {submitting ? 'Sending…' : 'Send to buyer'}
           </Button>
         </div>
       </div>
@@ -89,14 +105,17 @@ export function BidProposalButton({ requestId, hasPendingBid }: Props) {
   }
 
   return (
-    <Button
-      size="sm"
-      variant="outline"
-      onClick={() => setShowForm(true)}
-      className="gap-1.5"
-    >
-      <DollarSign className="h-4 w-4" />
-      Propose budget
-    </Button>
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <p className="text-sm text-muted-foreground">Suggest budget adjustment</p>
+        <p className="text-xs text-muted-foreground/70 mt-0.5">
+          Propose a revised amount after discussing requirements.
+        </p>
+      </div>
+      <Button size="sm" variant="outline" onClick={() => setShowForm(true)} className="shrink-0 gap-2">
+        <DollarSign className="h-3.5 w-3.5" />
+        Propose
+      </Button>
+    </div>
   )
 }

--- a/app/requests/[id]/commission-thread.tsx
+++ b/app/requests/[id]/commission-thread.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { useEffect, useRef, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Send } from 'lucide-react'
+
+type Message = {
+  id: string
+  senderId: string
+  body: string
+  readAt: string | null
+  createdAt: string
+}
+
+interface Props {
+  requestId: string
+  currentUserId: string
+  initialMessages: Message[]
+  canChat: boolean
+  currentUserName: string
+  otherUserName: string
+}
+
+function formatTime(value: string) {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(value))
+}
+
+function initials(name: string) {
+  return name.trim().split(/\s+/).map((w) => w[0]).join('').slice(0, 2).toUpperCase()
+}
+
+export function CommissionThread({
+  requestId,
+  currentUserId,
+  initialMessages,
+  canChat,
+  currentUserName,
+  otherUserName,
+}: Props) {
+  const router = useRouter()
+  const [messages, setMessages] = useState<Message[]>(initialMessages)
+  const [draft, setDraft] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  // Poll for new messages every 8 seconds
+  useEffect(() => {
+    if (!canChat) return
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/requests/${requestId}/messages`, { cache: 'no-store' })
+        if (res.ok) {
+          const data = await res.json()
+          setMessages(data.messages ?? [])
+        }
+      } catch {}
+    }, 8000)
+    return () => clearInterval(interval)
+  }, [requestId, canChat])
+
+  async function sendMessage() {
+    const body = draft.trim()
+    if (!body || isPending) return
+    setError(null)
+    setDraft('')
+
+    const optimistic: Message = {
+      id: `tmp-${Date.now()}`,
+      senderId: currentUserId,
+      body,
+      readAt: null,
+      createdAt: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, optimistic])
+
+    try {
+      const res = await fetch(`/api/requests/${requestId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error || 'Failed to send')
+      setMessages((prev) => prev.map((m) => (m.id === optimistic.id ? data.message : m)))
+      startTransition(() => router.refresh())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to send')
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id))
+      setDraft(body)
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
+
+  return (
+    <div className="flex flex-col">
+      <ScrollArea className="h-[380px] px-5 py-4">
+        {messages.length === 0 ? (
+          <div className="flex h-full min-h-[320px] items-center justify-center text-sm text-muted-foreground">
+            No messages yet.{canChat ? ' Start the conversation below.' : ''}
+          </div>
+        ) : (
+          <div className="space-y-4 pb-2">
+            {messages.map((m) => {
+              const isMine = m.senderId === currentUserId
+              const senderName = isMine ? currentUserName : otherUserName
+              return (
+                <div key={m.id} className={`flex gap-2.5 ${isMine ? 'flex-row-reverse' : ''}`}>
+                  <Avatar className="h-7 w-7 shrink-0 mt-0.5">
+                    <AvatarFallback className="text-[11px]">{initials(senderName)}</AvatarFallback>
+                  </Avatar>
+                  <div className={`flex flex-col gap-1 max-w-[75%] ${isMine ? 'items-end' : 'items-start'}`}>
+                    <div
+                      className={`rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed ${
+                        isMine
+                          ? 'bg-primary text-primary-foreground rounded-tr-sm'
+                          : 'bg-muted text-foreground rounded-tl-sm'
+                      }`}
+                    >
+                      {m.body}
+                    </div>
+                    <span className="text-[11px] text-muted-foreground px-1">{formatTime(m.createdAt)}</span>
+                  </div>
+                </div>
+              )
+            })}
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </ScrollArea>
+
+      {canChat ? (
+        <div className="border-t px-4 py-3">
+          {error && <p className="text-xs text-red-600 mb-2">{error}</p>}
+          <div className="flex gap-2 items-end">
+            <Textarea
+              placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={onKeyDown}
+              rows={2}
+              className="resize-none flex-1"
+              disabled={isPending}
+            />
+            <Button
+              size="icon"
+              onClick={sendMessage}
+              disabled={isPending || !draft.trim()}
+              className="shrink-0 h-10 w-10"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+          <p className="text-[11px] text-muted-foreground mt-1.5">Enter to send &bull; Shift+Enter for new line</p>
+        </div>
+      ) : (
+        <div className="border-t px-5 py-3 text-sm text-muted-foreground">
+          This request is closed — no new messages can be sent.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/requests/[id]/commission-thread.tsx
+++ b/app/requests/[id]/commission-thread.tsx
@@ -274,7 +274,6 @@ export function CommissionThread({
               <Send className="h-4 w-4" />
             </Button>
           </div>
-          <p className="text-[11px] text-muted-foreground">Enter to send &bull; Shift+Enter for new line</p>
         </div>
       ) : (
         <div className="border-t px-5 py-3 text-sm text-muted-foreground">

--- a/app/requests/[id]/commission-thread.tsx
+++ b/app/requests/[id]/commission-thread.tsx
@@ -147,9 +147,9 @@ export function CommissionThread({
 
   return (
     <div className="flex flex-col">
-      <ScrollArea className="h-[380px] px-5 py-4">
+      <ScrollArea className="h-[280px] sm:h-[380px] px-5 py-4">
         {messages.length === 0 ? (
-          <div className="flex h-full min-h-[320px] items-center justify-center text-sm text-muted-foreground">
+          <div className="flex h-full min-h-[220px] sm:min-h-[320px] items-center justify-center text-sm text-muted-foreground">
             No messages yet.{canChat ? ' Start the conversation below.' : ''}
           </div>
         ) : (
@@ -232,7 +232,7 @@ export function CommissionThread({
                   <Avatar className="h-7 w-7 shrink-0 mt-0.5">
                     <AvatarFallback className="text-[11px]">{initials(senderName)}</AvatarFallback>
                   </Avatar>
-                  <div className={`flex flex-col gap-1 max-w-[75%] ${isMine ? 'items-end' : 'items-start'}`}>
+                  <div className={`flex flex-col gap-1 max-w-[85%] sm:max-w-[75%] ${isMine ? 'items-end' : 'items-start'}`}>
                     <div
                       className={`rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap break-words ${
                         isMine

--- a/app/requests/[id]/commission-thread.tsx
+++ b/app/requests/[id]/commission-thread.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Send, DollarSign, Check, X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 
 type BidProposalStatus = 'pending' | 'accepted' | 'declined'
 
@@ -159,37 +160,43 @@ export function CommissionThread({
 
               if (m.type === 'bid_proposal' && m.bidProposal) {
                 const bp = m.bidProposal
-                const statusColor =
+                const cardClass =
                   bp.status === 'accepted'
-                    ? 'text-green-600'
+                    ? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30'
                     : bp.status === 'declined'
-                    ? 'text-red-600'
-                    : 'text-muted-foreground'
+                    ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/30'
+                    : 'border bg-card'
+                const badgeVariant =
+                  bp.status === 'accepted' ? 'default' : bp.status === 'declined' ? 'destructive' : 'secondary'
                 return (
-                  <div key={m.id} className="flex justify-center">
-                    <div className="rounded-lg border bg-card shadow-sm w-full max-w-sm p-4 space-y-3">
-                      <div className="flex items-center gap-2">
-                        <DollarSign className="h-4 w-4 text-muted-foreground" />
-                        <span className="text-sm font-semibold">Budget Proposal</span>
-                        <span className={`ml-auto text-xs font-medium capitalize ${statusColor}`}>
+                  <div key={m.id} className="flex justify-center py-1">
+                    <div className={`rounded-xl w-full max-w-xs p-4 space-y-3 ${cardClass}`}>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5">
+                          <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
+                          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                            Budget Proposal
+                          </span>
+                        </div>
+                        <Badge variant={badgeVariant} className="capitalize text-[10px] px-1.5 py-0">
                           {bp.status}
-                        </span>
+                        </Badge>
                       </div>
-                      <div className="text-center">
-                        <p className="text-2xl font-bold">${bp.amount.toLocaleString()}</p>
+                      <div className="text-center py-1">
+                        <p className="text-3xl font-bold tracking-tight">${bp.amount.toLocaleString()}</p>
                         {currentBudget != null && bp.status === 'pending' && (
-                          <p className="text-xs text-muted-foreground mt-0.5">
-                            Current budget: ${currentBudget.toLocaleString()}
+                          <p className="text-xs text-muted-foreground mt-1">
+                            Current: ${currentBudget.toLocaleString()}
                           </p>
                         )}
                       </div>
                       <p className="text-[11px] text-center text-muted-foreground">{formatTime(m.createdAt)}</p>
                       {!isArtist && bp.status === 'pending' && canChat && (
-                        <div className="flex gap-2">
+                        <div className="flex gap-2 pt-1">
                           <Button
                             size="sm"
                             variant="outline"
-                            className="flex-1 gap-1.5 text-red-600 border-red-200 hover:bg-red-50"
+                            className="flex-1 gap-1.5 border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300 dark:border-red-800 dark:hover:bg-red-950/50"
                             onClick={() => respondToBid(m.id, 'declined')}
                           >
                             <X className="h-3.5 w-3.5" />
@@ -197,13 +204,23 @@ export function CommissionThread({
                           </Button>
                           <Button
                             size="sm"
-                            className="flex-1 gap-1.5 bg-green-600 hover:bg-green-700"
+                            className="flex-1 gap-1.5 bg-green-600 hover:bg-green-700 text-white"
                             onClick={() => respondToBid(m.id, 'accepted')}
                           >
                             <Check className="h-3.5 w-3.5" />
                             Accept
                           </Button>
                         </div>
+                      )}
+                      {bp.status === 'accepted' && (
+                        <p className="text-xs text-center text-green-700 dark:text-green-400 font-medium">
+                          Budget updated to this amount
+                        </p>
+                      )}
+                      {bp.status === 'declined' && (
+                        <p className="text-xs text-center text-red-600 dark:text-red-400 font-medium">
+                          Proposal was declined
+                        </p>
                       )}
                     </div>
                   </div>

--- a/app/requests/[id]/commission-thread.tsx
+++ b/app/requests/[id]/commission-thread.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Send, DollarSign, Check, X } from 'lucide-react'
@@ -62,18 +61,9 @@ export function CommissionThread({
   const [error, setError] = useState<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
 
-  const [showBidForm, setShowBidForm] = useState(false)
-  const [bidAmount, setBidAmount] = useState('')
-  const [bidPending, setBidPending] = useState(false)
-  const [bidError, setBidError] = useState<string | null>(null)
-
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
-
-  const hasPendingBid = messages.some(
-    (m) => m.type === 'bid_proposal' && m.bidProposal?.status === 'pending'
-  )
 
   // Poll for new messages every 8 seconds
   useEffect(() => {
@@ -121,33 +111,6 @@ export function CommissionThread({
       setError(e instanceof Error ? e.message : 'Failed to send')
       setMessages((prev) => prev.filter((m) => m.id !== optimistic.id))
       setDraft(body)
-    }
-  }
-
-  async function submitBidProposal() {
-    const amount = parseFloat(bidAmount)
-    if (!Number.isFinite(amount) || amount <= 0) {
-      setBidError('Please enter a valid positive amount')
-      return
-    }
-    setBidError(null)
-    setBidPending(true)
-    try {
-      const res = await fetch(`/api/requests/${requestId}/messages`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type: 'bid_proposal', amount }),
-      })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(data?.error || 'Failed to submit proposal')
-      setMessages((prev) => [...prev, data.message])
-      setShowBidForm(false)
-      setBidAmount('')
-      startTransition(() => router.refresh())
-    } catch (e) {
-      setBidError(e instanceof Error ? e.message : 'Failed to submit proposal')
-    } finally {
-      setBidPending(false)
     }
   }
 
@@ -273,42 +236,8 @@ export function CommissionThread({
       </ScrollArea>
 
       {canChat ? (
-        <div className="border-t px-4 py-3 space-y-3">
+        <div className="border-t px-4 py-3 space-y-2">
           {error && <p className="text-xs text-red-600">{error}</p>}
-
-          {isArtist && showBidForm && (
-            <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
-              <p className="text-xs font-medium">Propose a new budget</p>
-              {bidError && <p className="text-xs text-red-600">{bidError}</p>}
-              <div className="flex gap-2 items-center">
-                <span className="text-sm text-muted-foreground">$</span>
-                <Input
-                  type="number"
-                  inputMode="decimal"
-                  placeholder="Enter amount"
-                  value={bidAmount}
-                  onChange={(e) => setBidAmount(e.target.value)}
-                  min={0}
-                  className="h-8 text-sm"
-                  disabled={bidPending}
-                />
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => { setShowBidForm(false); setBidAmount(''); setBidError(null) }}
-                  disabled={bidPending}
-                >
-                  Cancel
-                </Button>
-                <Button size="sm" onClick={submitBidProposal} disabled={bidPending}>
-                  {bidPending ? 'Sending…' : 'Send proposal'}
-                </Button>
-              </div>
-            </div>
-          )}
-
           <div className="flex gap-2 items-end">
             <Textarea
               placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
@@ -319,27 +248,14 @@ export function CommissionThread({
               className="resize-none flex-1"
               disabled={isPending}
             />
-            <div className="flex flex-col gap-1.5 shrink-0">
-              {isArtist && !showBidForm && !hasPendingBid && (
-                <Button
-                  size="icon"
-                  variant="outline"
-                  onClick={() => setShowBidForm(true)}
-                  title="Propose new budget"
-                  className="h-10 w-10"
-                >
-                  <DollarSign className="h-4 w-4" />
-                </Button>
-              )}
-              <Button
-                size="icon"
-                onClick={sendMessage}
-                disabled={isPending || !draft.trim()}
-                className="shrink-0 h-10 w-10"
-              >
-                <Send className="h-4 w-4" />
-              </Button>
-            </div>
+            <Button
+              size="icon"
+              onClick={sendMessage}
+              disabled={isPending || !draft.trim()}
+              className="shrink-0 h-10 w-10"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
           </div>
           <p className="text-[11px] text-muted-foreground">Enter to send &bull; Shift+Enter for new line</p>
         </div>

--- a/app/requests/[id]/commission-thread.tsx
+++ b/app/requests/[id]/commission-thread.tsx
@@ -4,14 +4,24 @@ import { useEffect, useRef, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
-import { Send } from 'lucide-react'
+import { Send, DollarSign, Check, X } from 'lucide-react'
+
+type BidProposalStatus = 'pending' | 'accepted' | 'declined'
+
+type BidProposal = {
+  amount: number
+  status: BidProposalStatus
+}
 
 type Message = {
   id: string
   senderId: string
+  type: 'text' | 'bid_proposal'
   body: string
+  bidProposal?: BidProposal | null
   readAt: string | null
   createdAt: string
 }
@@ -23,6 +33,8 @@ interface Props {
   canChat: boolean
   currentUserName: string
   otherUserName: string
+  isArtist: boolean
+  currentBudget: number | null
 }
 
 function formatTime(value: string) {
@@ -40,6 +52,8 @@ export function CommissionThread({
   canChat,
   currentUserName,
   otherUserName,
+  isArtist,
+  currentBudget,
 }: Props) {
   const router = useRouter()
   const [messages, setMessages] = useState<Message[]>(initialMessages)
@@ -48,9 +62,18 @@ export function CommissionThread({
   const [error, setError] = useState<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
 
+  const [showBidForm, setShowBidForm] = useState(false)
+  const [bidAmount, setBidAmount] = useState('')
+  const [bidPending, setBidPending] = useState(false)
+  const [bidError, setBidError] = useState<string | null>(null)
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
+
+  const hasPendingBid = messages.some(
+    (m) => m.type === 'bid_proposal' && m.bidProposal?.status === 'pending'
+  )
 
   // Poll for new messages every 8 seconds
   useEffect(() => {
@@ -76,7 +99,9 @@ export function CommissionThread({
     const optimistic: Message = {
       id: `tmp-${Date.now()}`,
       senderId: currentUserId,
+      type: 'text',
       body,
+      bidProposal: null,
       readAt: null,
       createdAt: new Date().toISOString(),
     }
@@ -99,6 +124,56 @@ export function CommissionThread({
     }
   }
 
+  async function submitBidProposal() {
+    const amount = parseFloat(bidAmount)
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setBidError('Please enter a valid positive amount')
+      return
+    }
+    setBidError(null)
+    setBidPending(true)
+    try {
+      const res = await fetch(`/api/requests/${requestId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'bid_proposal', amount }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error || 'Failed to submit proposal')
+      setMessages((prev) => [...prev, data.message])
+      setShowBidForm(false)
+      setBidAmount('')
+      startTransition(() => router.refresh())
+    } catch (e) {
+      setBidError(e instanceof Error ? e.message : 'Failed to submit proposal')
+    } finally {
+      setBidPending(false)
+    }
+  }
+
+  async function respondToBid(msgId: string, action: 'accepted' | 'declined') {
+    setError(null)
+    try {
+      const res = await fetch(`/api/requests/${requestId}/messages/${msgId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error || 'Failed to respond')
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === msgId && m.bidProposal
+            ? { ...m, bidProposal: { ...m.bidProposal, status: action } }
+            : m
+        )
+      )
+      startTransition(() => router.refresh())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to respond to bid')
+    }
+  }
+
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
@@ -118,6 +193,60 @@ export function CommissionThread({
             {messages.map((m) => {
               const isMine = m.senderId === currentUserId
               const senderName = isMine ? currentUserName : otherUserName
+
+              if (m.type === 'bid_proposal' && m.bidProposal) {
+                const bp = m.bidProposal
+                const statusColor =
+                  bp.status === 'accepted'
+                    ? 'text-green-600'
+                    : bp.status === 'declined'
+                    ? 'text-red-600'
+                    : 'text-muted-foreground'
+                return (
+                  <div key={m.id} className="flex justify-center">
+                    <div className="rounded-lg border bg-card shadow-sm w-full max-w-sm p-4 space-y-3">
+                      <div className="flex items-center gap-2">
+                        <DollarSign className="h-4 w-4 text-muted-foreground" />
+                        <span className="text-sm font-semibold">Budget Proposal</span>
+                        <span className={`ml-auto text-xs font-medium capitalize ${statusColor}`}>
+                          {bp.status}
+                        </span>
+                      </div>
+                      <div className="text-center">
+                        <p className="text-2xl font-bold">${bp.amount.toLocaleString()}</p>
+                        {currentBudget != null && bp.status === 'pending' && (
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            Current budget: ${currentBudget.toLocaleString()}
+                          </p>
+                        )}
+                      </div>
+                      <p className="text-[11px] text-center text-muted-foreground">{formatTime(m.createdAt)}</p>
+                      {!isArtist && bp.status === 'pending' && canChat && (
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="flex-1 gap-1.5 text-red-600 border-red-200 hover:bg-red-50"
+                            onClick={() => respondToBid(m.id, 'declined')}
+                          >
+                            <X className="h-3.5 w-3.5" />
+                            Decline
+                          </Button>
+                          <Button
+                            size="sm"
+                            className="flex-1 gap-1.5 bg-green-600 hover:bg-green-700"
+                            onClick={() => respondToBid(m.id, 'accepted')}
+                          >
+                            <Check className="h-3.5 w-3.5" />
+                            Accept
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )
+              }
+
               return (
                 <div key={m.id} className={`flex gap-2.5 ${isMine ? 'flex-row-reverse' : ''}`}>
                   <Avatar className="h-7 w-7 shrink-0 mt-0.5">
@@ -125,7 +254,7 @@ export function CommissionThread({
                   </Avatar>
                   <div className={`flex flex-col gap-1 max-w-[75%] ${isMine ? 'items-end' : 'items-start'}`}>
                     <div
-                      className={`rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed ${
+                      className={`rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap break-words ${
                         isMine
                           ? 'bg-primary text-primary-foreground rounded-tr-sm'
                           : 'bg-muted text-foreground rounded-tl-sm'
@@ -144,8 +273,42 @@ export function CommissionThread({
       </ScrollArea>
 
       {canChat ? (
-        <div className="border-t px-4 py-3">
-          {error && <p className="text-xs text-red-600 mb-2">{error}</p>}
+        <div className="border-t px-4 py-3 space-y-3">
+          {error && <p className="text-xs text-red-600">{error}</p>}
+
+          {isArtist && showBidForm && (
+            <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
+              <p className="text-xs font-medium">Propose a new budget</p>
+              {bidError && <p className="text-xs text-red-600">{bidError}</p>}
+              <div className="flex gap-2 items-center">
+                <span className="text-sm text-muted-foreground">$</span>
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="Enter amount"
+                  value={bidAmount}
+                  onChange={(e) => setBidAmount(e.target.value)}
+                  min={0}
+                  className="h-8 text-sm"
+                  disabled={bidPending}
+                />
+              </div>
+              <div className="flex gap-2 justify-end">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => { setShowBidForm(false); setBidAmount(''); setBidError(null) }}
+                  disabled={bidPending}
+                >
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={submitBidProposal} disabled={bidPending}>
+                  {bidPending ? 'Sending…' : 'Send proposal'}
+                </Button>
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-2 items-end">
             <Textarea
               placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
@@ -156,16 +319,29 @@ export function CommissionThread({
               className="resize-none flex-1"
               disabled={isPending}
             />
-            <Button
-              size="icon"
-              onClick={sendMessage}
-              disabled={isPending || !draft.trim()}
-              className="shrink-0 h-10 w-10"
-            >
-              <Send className="h-4 w-4" />
-            </Button>
+            <div className="flex flex-col gap-1.5 shrink-0">
+              {isArtist && !showBidForm && !hasPendingBid && (
+                <Button
+                  size="icon"
+                  variant="outline"
+                  onClick={() => setShowBidForm(true)}
+                  title="Propose new budget"
+                  className="h-10 w-10"
+                >
+                  <DollarSign className="h-4 w-4" />
+                </Button>
+              )}
+              <Button
+                size="icon"
+                onClick={sendMessage}
+                disabled={isPending || !draft.trim()}
+                className="shrink-0 h-10 w-10"
+              >
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
-          <p className="text-[11px] text-muted-foreground mt-1.5">Enter to send &bull; Shift+Enter for new line</p>
+          <p className="text-[11px] text-muted-foreground">Enter to send &bull; Shift+Enter for new line</p>
         </div>
       ) : (
         <div className="border-t px-5 py-3 text-sm text-muted-foreground">

--- a/app/requests/[id]/page.tsx
+++ b/app/requests/[id]/page.tsx
@@ -1,0 +1,183 @@
+import { notFound, redirect } from 'next/navigation'
+import { getServerSession } from 'next-auth'
+import Link from 'next/link'
+import { authOptions } from '@/lib/auth/authOptions'
+import { getRequestById } from '@/lib/db/requests'
+import { getUserById } from '@/lib/db/users'
+import { listMessages } from '@/lib/db/messages'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
+import RequestActions from '../_components/RequestActions'
+import { CommissionThread } from './commission-thread'
+
+export const dynamic = 'force-dynamic'
+
+type Status = 'REQUESTED' | 'ACCEPTED' | 'DECLINED' | 'COMPLETED'
+
+const STATUS_VARIANTS: Record<Status, 'secondary' | 'default' | 'destructive' | 'outline'> = {
+  REQUESTED: 'secondary',
+  ACCEPTED: 'default',
+  DECLINED: 'destructive',
+  COMPLETED: 'outline',
+}
+
+function formatDate(value: Date | string) {
+  const d = value instanceof Date ? value : new Date(value)
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(d)
+}
+
+function formatDueDate(value?: Date | string | null) {
+  if (!value) return null
+  const match = typeof value === 'string' ? /^(\d{4})-(\d{2})-(\d{2})/.exec(value) : null
+  const d = match
+    ? new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])))
+    : value instanceof Date ? value : new Date(String(value))
+  if (isNaN(d.getTime())) return null
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'long', timeZone: 'UTC' }).format(d)
+}
+
+interface PageProps { params: Promise<{ id: string }> }
+
+export async function generateMetadata({ params }: PageProps) {
+  const { id } = await params
+  const request = await getRequestById(id)
+  return { title: request?.title ? `${request.title} | Artify` : 'Request | Artify' }
+}
+
+export default async function RequestDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) redirect('/login')
+
+  const request = await getRequestById(id)
+  if (!request) return notFound()
+
+  const uid = session.user.id
+  const isParty = String(request.artistId) === uid || String(request.customerId) === uid
+  if (!isParty) return notFound()
+
+  const isArtist = String(request.artistId) === uid
+  const canChat = request.status === 'REQUESTED' || request.status === 'ACCEPTED'
+
+  const [artistUser, customerUser, rawMessages] = await Promise.all([
+    getUserById(String(request.artistId)),
+    getUserById(String(request.customerId)),
+    listMessages(id),
+  ])
+
+  const initialMessages = rawMessages.map((m) => ({
+    id: String(m._id),
+    senderId: String(m.senderId),
+    body: m.body,
+    readAt: m.readAt?.toISOString() ?? null,
+    createdAt: m.createdAt.toISOString(),
+  }))
+
+  return (
+    <div className="container mx-auto max-w-3xl py-8 px-4">
+      <Link
+        href="/requests"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to requests
+      </Link>
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">{request.title || 'Untitled request'}</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {isArtist
+              ? `From ${customerUser?.name ?? 'Buyer'}`
+              : `To ${artistUser?.name ?? 'Artist'}`}
+            {' · '}
+            {formatDate(request.createdAt)}
+          </p>
+        </div>
+        <Badge variant={STATUS_VARIANTS[request.status]}>{request.status}</Badge>
+      </div>
+
+      {/* Details card */}
+      <div className="rounded-lg border bg-card p-5 space-y-4 mb-6">
+        <section>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Brief</h2>
+          <p className="text-sm leading-relaxed whitespace-pre-wrap">{request.brief}</p>
+        </section>
+
+        <Separator />
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Budget</p>
+            <p>{typeof request.budget === 'number' ? `$${request.budget.toLocaleString()}` : 'Not set'}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Due date</p>
+            <p>{formatDueDate(request.dueDate) ?? 'Not set'}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Status</p>
+            <p className="capitalize">{request.status.toLowerCase()}</p>
+          </div>
+        </div>
+
+        {request.referenceUrls && request.referenceUrls.length > 0 && (
+          <>
+            <Separator />
+            <section>
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Reference links
+              </h2>
+              <div className="space-y-2">
+                {request.referenceUrls.map((url) => (
+                  <a
+                    key={url}
+                    href={url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-2 text-sm text-primary hover:underline truncate"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                    {url}
+                  </a>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+
+      {/* Artist-only status actions */}
+      {isArtist && (request.status === 'REQUESTED' || request.status === 'ACCEPTED') && (
+        <div className="flex items-center gap-3 mb-6 p-4 rounded-lg border bg-muted/30">
+          <span className="text-sm text-muted-foreground flex-1">
+            {request.status === 'REQUESTED' ? 'Respond to this request:' : 'Ready to wrap up?'}
+          </span>
+          <RequestActions id={String(request._id)} status={request.status} />
+        </div>
+      )}
+
+      {/* Chat thread */}
+      <div className="rounded-lg border">
+        <div className="px-5 py-4 border-b">
+          <h2 className="font-semibold">Messages</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {canChat
+              ? `Chat with the ${isArtist ? 'buyer' : 'artist'} about this request.`
+              : 'This request is closed — messages are read-only.'}
+          </p>
+        </div>
+        <CommissionThread
+          requestId={id}
+          currentUserId={uid}
+          initialMessages={initialMessages}
+          canChat={canChat}
+          currentUserName={session.user.name ?? 'You'}
+          otherUserName={isArtist ? (customerUser?.name ?? 'Buyer') : (artistUser?.name ?? 'Artist')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/requests/[id]/page.tsx
+++ b/app/requests/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Separator } from '@/components/ui/separator'
 import { ArrowLeft, ExternalLink } from 'lucide-react'
 import RequestActions from '../_components/RequestActions'
 import { CommissionThread } from './commission-thread'
+import { BidProposalButton } from './bid-proposal-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -65,6 +66,10 @@ export default async function RequestDetailPage({ params }: PageProps) {
     getUserById(String(request.customerId)),
     listMessages(id),
   ])
+
+  const hasPendingBid = rawMessages.some(
+    (m) => m.type === 'bid_proposal' && m.bidProposal?.status === 'pending'
+  )
 
   const initialMessages = rawMessages.map((m) => ({
     id: String(m._id),
@@ -153,11 +158,20 @@ export default async function RequestDetailPage({ params }: PageProps) {
 
       {/* Artist-only status actions */}
       {isArtist && (request.status === 'REQUESTED' || request.status === 'ACCEPTED') && (
-        <div className="flex items-center gap-3 mb-6 p-4 rounded-lg border bg-muted/30">
-          <span className="text-sm text-muted-foreground flex-1">
-            {request.status === 'REQUESTED' ? 'Respond to this request:' : 'Ready to wrap up?'}
-          </span>
-          <RequestActions id={String(request._id)} status={request.status} />
+        <div className="flex flex-col gap-3 mb-6 p-4 rounded-lg border bg-muted/30">
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground flex-1">
+              {request.status === 'REQUESTED' ? 'Respond to this request:' : 'Ready to wrap up?'}
+            </span>
+            <RequestActions id={String(request._id)} status={request.status} />
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground flex-1">Budget negotiation:</span>
+            <BidProposalButton
+              requestId={String(request._id)}
+              hasPendingBid={hasPendingBid}
+            />
+          </div>
         </div>
       )}
 

--- a/app/requests/[id]/page.tsx
+++ b/app/requests/[id]/page.tsx
@@ -158,15 +158,15 @@ export default async function RequestDetailPage({ params }: PageProps) {
 
       {/* Artist-only status actions */}
       {isArtist && (request.status === 'REQUESTED' || request.status === 'ACCEPTED') && (
-        <div className="flex flex-col gap-3 mb-6 p-4 rounded-lg border bg-muted/30">
-          <div className="flex items-center gap-3">
+        <div className="mb-6 rounded-lg border bg-muted/30 overflow-hidden">
+          <div className="flex items-center gap-3 px-4 py-3">
             <span className="text-sm text-muted-foreground flex-1">
               {request.status === 'REQUESTED' ? 'Respond to this request:' : 'Ready to wrap up?'}
             </span>
             <RequestActions id={String(request._id)} status={request.status} />
           </div>
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground flex-1">Budget negotiation:</span>
+          <Separator />
+          <div className="px-4 py-3">
             <BidProposalButton
               requestId={String(request._id)}
               hasPendingBid={hasPendingBid}

--- a/app/requests/[id]/page.tsx
+++ b/app/requests/[id]/page.tsx
@@ -69,7 +69,9 @@ export default async function RequestDetailPage({ params }: PageProps) {
   const initialMessages = rawMessages.map((m) => ({
     id: String(m._id),
     senderId: String(m.senderId),
+    type: m.type,
     body: m.body,
+    bidProposal: m.bidProposal ?? null,
     readAt: m.readAt?.toISOString() ?? null,
     createdAt: m.createdAt.toISOString(),
   }))
@@ -176,6 +178,8 @@ export default async function RequestDetailPage({ params }: PageProps) {
           canChat={canChat}
           currentUserName={session.user.name ?? 'You'}
           otherUserName={isArtist ? (customerUser?.name ?? 'Buyer') : (artistUser?.name ?? 'Artist')}
+          isArtist={isArtist}
+          currentBudget={request.budget ?? null}
         />
       </div>
     </div>

--- a/app/requests/_components/RequestActions.tsx
+++ b/app/requests/_components/RequestActions.tsx
@@ -62,7 +62,7 @@ export default function RequestActions({
       <div className="flex items-center gap-2">
         <AlertDialog>
           <AlertDialogTrigger asChild>
-            <Button size="sm" disabled={isPending}>Mark as completed</Button>
+            <Button disabled={isPending}>Mark as completed</Button>
           </AlertDialogTrigger>
           <AlertDialogContent>
             <AlertDialogHeader>
@@ -88,7 +88,7 @@ export default function RequestActions({
     <div className="flex items-center gap-2">
       <AlertDialog>
         <AlertDialogTrigger asChild>
-          <Button size="sm" disabled={isPending}>Accept</Button>
+          <Button disabled={isPending}>Accept</Button>
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -105,7 +105,7 @@ export default function RequestActions({
       </AlertDialog>
       <AlertDialog>
         <AlertDialogTrigger asChild>
-          <Button size="sm" variant="outline" disabled={isPending}>Decline</Button>
+          <Button variant="outline" disabled={isPending}>Decline</Button>
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/app/requests/_components/SellerRequestDetailsDialog.tsx
+++ b/app/requests/_components/SellerRequestDetailsDialog.tsx
@@ -123,8 +123,8 @@ export default function SellerRequestDetailsDialog({
         </button>
       </DialogTrigger>
 
-      <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto p-0">
-        <div className="border-b pl-6 pr-14 py-5">
+      <DialogContent className="max-h-[90vh] w-full sm:max-w-2xl overflow-y-auto p-0">
+        <div className="border-b pl-4 pr-12 py-4 sm:pl-6 sm:pr-14 sm:py-5">
           <div className="mb-3 flex items-start justify-between gap-3">
             <div className="min-w-0">
               <DialogHeader className="space-y-2 text-left">
@@ -146,7 +146,7 @@ export default function SellerRequestDetailsDialog({
           </div>
         </div>
 
-        <div className="space-y-6 px-6 py-5">
+        <div className="space-y-6 px-4 py-4 sm:px-6 sm:py-5">
           <section>
             <h3 className="text-sm font-semibold">Request brief</h3>
             <div className="mt-2 whitespace-pre-wrap rounded-md border bg-muted/20 p-4 text-sm leading-6">
@@ -186,8 +186,8 @@ export default function SellerRequestDetailsDialog({
           ) : null}
         </div>
 
-        <DialogFooter className="border-t px-6 py-4 flex-wrap gap-2">
-          <Button asChild variant="outline" size="sm" className="gap-1.5">
+        <DialogFooter className="border-t px-4 py-3 sm:px-6 sm:py-4 flex-wrap gap-2">
+          <Button asChild variant="outline" className="gap-1.5">
             <Link href={`/requests/${request.id}`} onClick={() => setOpen(false)}>
               <MessageSquare className="h-4 w-4" />
               View messages
@@ -200,7 +200,7 @@ export default function SellerRequestDetailsDialog({
               onSuccess={() => setOpen(false)}
             />
           ) : (
-            <Button type="button" variant="outline" size="sm" onClick={() => setOpen(false)}>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
               Close
             </Button>
           )}

--- a/app/requests/_components/SellerRequestDetailsDialog.tsx
+++ b/app/requests/_components/SellerRequestDetailsDialog.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useState } from 'react'
-import { ExternalLink } from 'lucide-react'
+import Link from 'next/link'
+import { ExternalLink, MessageSquare } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -185,21 +186,25 @@ export default function SellerRequestDetailsDialog({
           ) : null}
         </div>
 
-        {request.status === 'REQUESTED' || request.status === 'ACCEPTED' ? (
-          <DialogFooter className="border-t px-6 py-4">
+        <DialogFooter className="border-t px-6 py-4 flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link href={`/requests/${request.id}`} onClick={() => setOpen(false)}>
+              <MessageSquare className="h-4 w-4" />
+              View messages
+            </Link>
+          </Button>
+          {request.status === 'REQUESTED' || request.status === 'ACCEPTED' ? (
             <RequestActions
               id={request.id}
               status={request.status}
               onSuccess={() => setOpen(false)}
             />
-          </DialogFooter>
-        ) : (
-          <DialogFooter className="border-t px-6 py-4">
-            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+          ) : (
+            <Button type="button" variant="outline" size="sm" onClick={() => setOpen(false)}>
               Close
             </Button>
-          </DialogFooter>
-        )}
+          )}
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/app/requests/_components/SellerRequestDetailsDialog.tsx
+++ b/app/requests/_components/SellerRequestDetailsDialog.tsx
@@ -124,7 +124,7 @@ export default function SellerRequestDetailsDialog({
       </DialogTrigger>
 
       <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto p-0">
-        <div className="border-b px-6 py-5">
+        <div className="border-b pl-6 pr-14 py-5">
           <div className="mb-3 flex items-start justify-between gap-3">
             <div className="min-w-0">
               <DialogHeader className="space-y-2 text-left">

--- a/app/requests/new/request-form.tsx
+++ b/app/requests/new/request-form.tsx
@@ -77,7 +77,7 @@ export function CommissionRequestForm({ presetArtist, viewerId }: { presetArtist
     }
     const payload = parsed.data
     try {
-      const res = await fetch('/api/commissions', {
+      const res = await fetch('/api/requests', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -90,7 +90,7 @@ export function CommissionRequestForm({ presetArtist, viewerId }: { presetArtist
       }
       // Notify and redirect to the commissions hub
       toast({ title: 'Request sent', description: 'We\'ve notified the artist.' })
-      startTransition(() => router.push('/commissions'))
+      startTransition(() => router.push('/requests'))
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
     }

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -94,10 +94,10 @@ export default async function RequestsHubPage() {
     const archiveWithCustomerNames = allRequests.filter((c) => c.status !== 'REQUESTED')
 
     return (
-      <div className="container mx-auto max-w-3xl py-10">
+      <div className="container mx-auto max-w-3xl px-4 py-6 sm:py-10">
         <RouteRefresher intervalMs={15000} onMount onFocus onInterval />
         <div className="flex items-center justify-between mb-2">
-          <h1 className="text-3xl font-bold">Incoming requests</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold">Incoming requests</h1>
           <RefreshHint intervalMs={15000} />
         </div>
         <div className="h-4" />
@@ -182,10 +182,10 @@ export default async function RequestsHubPage() {
   // Customer view
   const my = await listCustomerRequests(session.user.id, 1, 20)
   return (
-    <div className="container mx-auto max-w-3xl py-10">
+    <div className="container mx-auto max-w-3xl px-4 py-6 sm:py-10">
       <RouteRefresher intervalMs={0} onMount onFocus onInterval={false} />
       <div className="flex items-center justify-between mb-2">
-        <h1 className="text-3xl font-bold">Your requests</h1>
+        <h1 className="text-2xl sm:text-3xl font-bold">Your requests</h1>
         <RefreshHint intervalMs={0} />
       </div>
       <div className="h-4" />

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -209,9 +209,9 @@ export default async function RequestsHubPage() {
           ) : (
             <div className="divide-y rounded-md border">
               {my.items.map((c) => (
-                <div key={String(c._id)} className="px-4">
+                <Link key={String(c._id)} href={`/requests/${String(c._id)}`} className="block px-4 hover:bg-muted/40 transition-colors">
                   <RequestRow c={c} />
-                </div>
+                </Link>
               ))}
             </div>
           )}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -172,9 +172,6 @@ export default function Navbar() {
                       <Link href="/dashboard/favorites" className={linkClass("/dashboard/favorites")}>
                         My favorites
                       </Link>
-                      <Link href="/requests" className={linkClass("/requests")}>
-                        Requests
-                      </Link>
                     </>
                   ) : null}
                   {session?.user?.role === 'ARTIST' ? (

--- a/lib/db/messages.ts
+++ b/lib/db/messages.ts
@@ -1,0 +1,48 @@
+import { Collection, ObjectId } from 'mongodb'
+import { getMongoDatabase } from '@/lib/db'
+
+export interface MessageDoc {
+  _id?: ObjectId
+  requestId: ObjectId
+  senderId: ObjectId
+  body: string
+  readAt?: Date | null
+  createdAt: Date
+}
+
+export async function getMessagesCollection(): Promise<Collection<MessageDoc>> {
+  const db = await getMongoDatabase()
+  const col = db.collection<MessageDoc>('messages')
+  await col.createIndexes([
+    { key: { requestId: 1, createdAt: 1 }, name: 'requestId_createdAt' },
+    { key: { requestId: 1, readAt: 1 }, name: 'requestId_readAt' },
+  ])
+  return col
+}
+
+export async function listMessages(requestId: string | ObjectId, limit = 200) {
+  const col = await getMessagesCollection()
+  const _id = typeof requestId === 'string' ? new ObjectId(requestId) : requestId
+  return col.find({ requestId: _id }).sort({ createdAt: 1 }).limit(limit).toArray()
+}
+
+export async function createMessage(input: {
+  requestId: ObjectId
+  senderId: ObjectId
+  body: string
+}) {
+  const col = await getMessagesCollection()
+  const doc: MessageDoc = { ...input, readAt: null, createdAt: new Date() }
+  const res = await col.insertOne(doc)
+  return { ...doc, _id: res.insertedId }
+}
+
+export async function markMessagesRead(requestId: string | ObjectId, recipientId: string | ObjectId) {
+  const col = await getMessagesCollection()
+  const _requestId = typeof requestId === 'string' ? new ObjectId(requestId) : requestId
+  const _recipientId = typeof recipientId === 'string' ? new ObjectId(recipientId) : recipientId
+  return col.updateMany(
+    { requestId: _requestId, senderId: { $ne: _recipientId }, readAt: null },
+    { $set: { readAt: new Date() } }
+  )
+}

--- a/lib/db/messages.ts
+++ b/lib/db/messages.ts
@@ -1,11 +1,20 @@
 import { Collection, ObjectId } from 'mongodb'
 import { getMongoDatabase } from '@/lib/db'
 
+export type BidProposalStatus = 'pending' | 'accepted' | 'declined'
+
+export interface BidProposal {
+  amount: number
+  status: BidProposalStatus
+}
+
 export interface MessageDoc {
   _id?: ObjectId
   requestId: ObjectId
   senderId: ObjectId
+  type: 'text' | 'bid_proposal'
   body: string
+  bidProposal?: BidProposal
   readAt?: Date | null
   createdAt: Date
 }
@@ -26,10 +35,19 @@ export async function listMessages(requestId: string | ObjectId, limit = 200) {
   return col.find({ requestId: _id }).sort({ createdAt: 1 }).limit(limit).toArray()
 }
 
+export async function getMessageById(id: string | ObjectId) {
+  const col = await getMessagesCollection()
+  const _id = typeof id === 'string' ? (ObjectId.isValid(id) ? new ObjectId(id) : undefined) : id
+  if (!_id) return null
+  return col.findOne({ _id })
+}
+
 export async function createMessage(input: {
   requestId: ObjectId
   senderId: ObjectId
+  type: 'text' | 'bid_proposal'
   body: string
+  bidProposal?: BidProposal
 }) {
   const col = await getMessagesCollection()
   const doc: MessageDoc = { ...input, readAt: null, createdAt: new Date() }
@@ -45,4 +63,18 @@ export async function markMessagesRead(requestId: string | ObjectId, recipientId
     { requestId: _requestId, senderId: { $ne: _recipientId }, readAt: null },
     { $set: { readAt: new Date() } }
   )
+}
+
+export async function hasPendingBidProposal(requestId: string | ObjectId): Promise<boolean> {
+  const col = await getMessagesCollection()
+  const _id = typeof requestId === 'string' ? new ObjectId(requestId) : requestId
+  const count = await col.countDocuments({ requestId: _id, type: 'bid_proposal', 'bidProposal.status': 'pending' })
+  return count > 0
+}
+
+export async function updateBidProposalStatus(id: string | ObjectId, status: 'accepted' | 'declined') {
+  const col = await getMessagesCollection()
+  const _id = typeof id === 'string' ? (ObjectId.isValid(id) ? new ObjectId(id) : undefined) : id
+  if (!_id) return { matchedCount: 0, modifiedCount: 0 }
+  return col.updateOne({ _id }, { $set: { 'bidProposal.status': status } })
 }

--- a/lib/db/requests.ts
+++ b/lib/db/requests.ts
@@ -108,3 +108,11 @@ export async function updateRequestStatus(id: string | ObjectId, status: Request
   if (!_id) return { matchedCount: 0, modifiedCount: 0 }
   return col.updateOne({ _id }, { $set: { status, updatedAt: new Date() } })
 }
+
+/** Update request budget (called when a bid proposal is accepted). */
+export async function updateRequestBudget(id: string | ObjectId, budget: number) {
+  const col = await getRequestsCollection()
+  const _id = typeof id === 'string' ? (ObjectId.isValid(id) ? new ObjectId(id) : undefined) : id
+  if (!_id) return { matchedCount: 0, modifiedCount: 0 }
+  return col.updateOne({ _id }, { $set: { budget, updatedAt: new Date() } })
+}

--- a/lib/schemas/message.ts
+++ b/lib/schemas/message.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const MessageCreateSchema = z.object({
+  body: z.string().trim().min(1, 'Message cannot be empty').max(2000, 'Message too long'),
+})

--- a/lib/schemas/message.ts
+++ b/lib/schemas/message.ts
@@ -1,5 +1,14 @@
 import { z } from 'zod'
 
-export const MessageCreateSchema = z.object({
+export const TextMessageSchema = z.object({
   body: z.string().trim().min(1, 'Message cannot be empty').max(2000, 'Message too long'),
+})
+
+export const BidProposalCreateSchema = z.object({
+  type: z.literal('bid_proposal'),
+  amount: z.number().positive('Amount must be a positive number'),
+})
+
+export const BidProposalResponseSchema = z.object({
+  action: z.enum(['accepted', 'declined']),
 })

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    container: {
+      padding: '1rem',
+    },
     extend: {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
## Summary

Adds a full messaging thread to every commission request so buyers and artists can communicate directly on the platform — no more guessing games after a request is submitted.

- New `messages` MongoDB collection scoped by `requestId`
- REST API at `/api/requests/[id]/messages` (GET + POST)
- New commission detail page at `/requests/[id]` with brief, status actions, and chat in one view
- Client-side chat component with optimistic sends, 8-second polling, and auto-scroll
- Customer request rows in the hub are now clickable links to the detail page
- Artist request dialog gets a **"View messages"** button linking to the detail page

## What was built

### New files
| File | Purpose |
|---|---|
| `lib/db/messages.ts` | `MessageDoc` schema + `createMessage`, `listMessages`, `markMessagesRead` helpers |
| `lib/schemas/message.ts` | Zod validation — body 1–2000 chars |
| `app/api/requests/[id]/messages/route.ts` | GET (fetch thread + mark read) · POST (send message) |
| `app/requests/[id]/page.tsx` | Commission detail page — brief, budget, references, status actions, chat |
| `app/requests/[id]/commission-thread.tsx` | Client chat UI — optimistic updates, polling, read-only for closed requests |

### Modified files
| File | Change |
|---|---|
| `app/requests/page.tsx` | Customer rows are now `<Link>` to `/requests/[id]` |
| `app/requests/_components/SellerRequestDetailsDialog.tsx` | Added "View messages" button in dialog footer |

## Design decisions

- **Chat is open from `REQUESTED` state** — artists can ask clarifying questions before accepting; customers can add context they forgot
- **Chat locks on `DECLINED` / `COMPLETED`** — messages become read-only; no new messages allowed via API either
- **Polling at 8 seconds** — consistent with the existing 15-second pattern in the requests hub; no new dependencies or infrastructure needed (Vercel free tier doesn't support WebSockets)
- **Optimistic sends** — message appears immediately, replaced by the real document on success or rolled back on failure
- **`markMessagesRead` on GET** — reading the thread automatically marks the other party's messages as read

## Test plan

- [x] As a customer, submit a commission request and click the row in "My Requests" — confirm it navigates to `/requests/[id]`
- [x] On the detail page, confirm the brief, budget, due date, and reference links render correctly
- [x] Type a message and press Enter — confirm it appears immediately (optimistic) and persists after reload
- [x] Press Shift+Enter — confirm it inserts a newline instead of sending
- [ ] Open the same request in a second browser tab as the artist — send a message; confirm it appears in the customer tab within ~8 seconds
- [x] As artist, open the request dialog from the hub — confirm "View messages" button is present and navigates to the detail page
- [ ] Accept the request, then send a message from both sides — confirm chat still works in `ACCEPTED` state
- [ ] Decline or complete a request — confirm the input area is replaced with "This request is closed" and the POST API returns 400
- [ ] Confirm non-party users get a 404 on the detail page (not a 403 — no information leakage)

https://claude.ai/code/session_01HSAu82rXfxCz8Q1UgRY9f8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSAu82rXfxCz8Q1UgRY9f8)_